### PR TITLE
Display_Options: display options even when they don't have help field

### DIFF
--- a/src/clic-subcommand-instance.adb
+++ b/src/clic-subcommand-instance.adb
@@ -707,7 +707,7 @@ package body CLIC.Subcommand.Instance is
          Has_Short : constant Boolean := Short_Switch not in " " | "";
          Has_Long  : constant Boolean := Long_Switch not in " " | "";
       begin
-         if (not Has_Short and not Has_Long) or Help = "" then
+         if not Has_Short and then not Has_Long then
             return;
          end if;
 


### PR DESCRIPTION
I was surprised not to see my switch in the help, and it was because I didn't set an help text.
Even if it's always better to have a help defined, I think we should still display the switch because it's here, it will be parsed and there is an impact on the tool behavior.