### PR TITLE
Just a little proof-of-concept on generating a man page from the info that we have in CLIC

### DIFF
--- a/example/src/clic_ex-commands-subsub.ads
+++ b/example/src/clic_ex-commands-subsub.ads
@@ -22,7 +22,12 @@ package CLIC_Ex.Commands.Subsub is
 
    overriding
    function Long_Description (Cmd : Instance) return AAA.Strings.Vector
-   is (AAA.Strings.Empty_Vector);
+   is (AAA.Strings.Empty_Vector
+       .Append ("Long description Line1")
+       .Append ("Long description Line2")
+       .Append ("Long description Line3")
+       .New_Line
+       .Append ("Long description Line2"));
 
    overriding
    procedure Setup_Switches

--- a/example/src/clic_ex-commands-switches_and_args.ads
+++ b/example/src/clic_ex-commands-switches_and_args.ads
@@ -22,7 +22,12 @@ package CLIC_Ex.Commands.Switches_And_Args is
 
    overriding
    function Long_Description (Cmd : Instance) return AAA.Strings.Vector
-   is (AAA.Strings.Empty_Vector);
+   is (AAA.Strings.Empty_Vector
+       .Append ("Long description Line1")
+       .Append ("Long description Line2")
+       .Append ("Long description Line3")
+       .New_Line
+       .Append ("Long description Line2"));
 
    overriding
    procedure Setup_Switches

--- a/example/src/clic_ex-commands.adb
+++ b/example/src/clic_ex-commands.adb
@@ -20,6 +20,8 @@ package body CLIC_Ex.Commands is
    No_TTY : aliased Boolean := False;
    --  Used to disable control characters in output
 
+   Print_Man : aliased Boolean := False;
+
    -------------------------
    -- Set_Global_Switches --
    -------------------------
@@ -48,6 +50,11 @@ package body CLIC_Ex.Commands is
                      No_TTY'Access,
                      Long_Switch => "--no-tty",
                      Help        => "Disables control characters in output");
+
+      Define_Switch (Config,
+                     Print_Man'Access,
+                     Long_Switch => "--man",
+                     Help        => "Display man page source for the tool");
    end Set_Global_Switches;
 
    -------------
@@ -67,17 +74,25 @@ package body CLIC_Ex.Commands is
          --  This may still not enable color if TTY is detected to be incapable
       end if;
 
-      Sub_Cmd.Execute;
+      if Print_Man then
+         Sub_Cmd.Print_Man_Page ("short tool description",
+                                 AAA.Strings.Empty_Vector
+                                 .Append ("Line 1 of long description.")
+                                 .New_Line
+                                 .Append ("Line 2 of long description."));
+      else
+         Sub_Cmd.Execute;
+      end if;
    end Execute;
 
 begin
 
    Sub_Cmd.Register (new Sub_Cmd.Builtin_Help);
    Sub_Cmd.Register (new CLIC_Ex.Commands.Config.Instance);
-   Sub_Cmd.Register (new CLIC_Ex.Commands.TTY.Instance);
-   Sub_Cmd.Register (new CLIC_Ex.Commands.User_Input.Instance);
-   Sub_Cmd.Register (new CLIC_Ex.Commands.Switches_And_Args.Instance);
-   Sub_Cmd.Register (new CLIC_Ex.Commands.Subsub.Instance);
+   Sub_Cmd.Register ("Group1", new CLIC_Ex.Commands.TTY.Instance);
+   Sub_Cmd.Register ("Group1", new CLIC_Ex.Commands.User_Input.Instance);
+   Sub_Cmd.Register ("Group2", new CLIC_Ex.Commands.Switches_And_Args.Instance);
+   Sub_Cmd.Register ("Group2", new CLIC_Ex.Commands.Subsub.Instance);
    Sub_Cmd.Register (new CLIC_Ex.Commands.Topics.Example.Instance);
 
    Sub_Cmd.Set_Alias ("blink", AAA.Strings.Empty_Vector

--- a/src/clic-subcommand-instance-print_man_page.adb
+++ b/src/clic-subcommand-instance-print_man_page.adb
@@ -1,0 +1,133 @@
+separate (CLIC.Subcommand.Instance)
+procedure Print_Man_Page (Short_Description : String;
+                          Long_Description  : AAA.Strings.Vector)
+is
+   use AAA.Strings;
+
+   -------------------
+   -- Put_Long_Desc --
+   -------------------
+
+   procedure Put_Long_Desc (Desc : AAA.Strings.Vector) is
+   begin
+      if not Desc.Is_Empty then
+         Put_Line (".P");
+         for Line of Desc loop
+            if Line = "" then
+               Put_Line (".P");
+            else
+               Put_Line (Line);
+            end if;
+         end loop;
+      end if;
+   end Put_Long_Desc;
+
+   -------------------
+   -- Format_Switch --
+   -------------------
+
+   function Format_Switch (Sw : Switch_Info) return String is
+      Short : constant String := Trim (To_String (Sw.Switch), '-');
+      Long  : constant String := Trim (To_String (Sw.Long_Switch), '-');
+   begin
+      if Short = "" then
+         return "\-\-" & Long;
+      elsif Long = "" then
+         return "\-" & Short;
+      else
+         return "\-" & Short & ", \-\-" & Long;
+      end if;
+   end Format_Switch;
+
+   ------------------
+   -- Put_Switches --
+   ------------------
+
+   procedure Put_Switches (C : Switches_Configuration) is
+   begin
+      for Sw of C.Info loop
+         Put_Line (".PP");
+         Put_Line (Format_Switch (Sw));
+         Put_Line (".RS");
+         Put_Line (To_String (Sw.Help));
+         Put_Line (".RE");
+      end loop;
+   end Put_Switches;
+
+   ------------------
+   -- Put_Commands --
+   ------------------
+
+   procedure Put_Commands is
+      use Command_Maps;
+      use Group_Maps;
+
+      procedure Put_Command (Cmd : not null Command_Access) is
+         Switches : Switches_Configuration;
+      begin
+         Cmd.Setup_Switches (Switches);
+
+         Put_Line (".PP");
+         Put_Line ("\fB" & Cmd.Name & "\fR " & Cmd.Usage_Custom_Parameters);
+         Put_Line (".RS"); -- Start indent
+         Put_Line (Cmd.Short_Description);
+         Put_Long_Desc (Cmd.Long_Description);
+         Put_Switches (Switches);
+         Put_Line (".RE"); -- End indent
+
+         Clear (Switches);
+      end Put_Command;
+
+   begin
+      if Registered_Commands.Is_Empty then
+         return;
+      end if;
+
+      Put_Line (".SH COMMANDS");
+
+      for Name of Not_In_A_Group loop
+         Put_Command (Registered_Commands (To_Unbounded_String (Name)));
+      end loop;
+
+      for Iter in Registered_Groups.Iterate loop
+         declare
+            Group : constant String := To_String (Key (Iter));
+         begin
+            Put_Line (".SH " & To_Upper_Case (Group) & " COMMANDS");
+            for Name of Element (Iter) loop
+               Put_Command
+                 (Registered_Commands (To_Unbounded_String (Name)));
+            end loop;
+         end;
+      end loop;
+   end Put_Commands;
+
+   ----------------
+   -- Put_Topics --
+   ----------------
+
+   procedure Put_Topics is
+      use Topic_Maps;
+   begin
+      Put_Line (".SH MISC");
+      for Elt in Registered_Topics.Iterate loop
+         Put_Line (".SS " & Element (Elt).Title);
+         Put_Long_Desc (Element (Elt).Content);
+      end loop;
+   end Put_Topics;
+begin
+   Put_Line (".TH " & Main_Command_Name & " 1");
+   Put_Line (".SH NAME");
+   Put_Line (Main_Command_Name & " - " & Short_Description);
+   Put_Line (".SH SYNOPSIS");
+   Put_Line (".B " & Main_Command_Name & " [global options] " &
+               "<command> [command options] [<arguments>]");
+   Put_Line (".SH DESCRIPTION");
+   Put_Long_Desc (Long_Description);
+
+   Put_Line (".SH GLOBAL OPTIONS");
+
+   Put_Switches (Global_Config);
+   Put_Commands;
+   Put_Topics;
+end Print_Man_Page;

--- a/src/clic-subcommand-instance.adb
+++ b/src/clic-subcommand-instance.adb
@@ -823,6 +823,14 @@ package body CLIC.Subcommand.Instance is
       end if;
    end Display_Help;
 
+   --------------------
+   -- Print_Man_Page --
+   --------------------
+
+   procedure Print_Man_Page (Short_Description : String;
+                             Long_Description  : AAA.Strings.Vector)
+   is separate;
+
    -------------
    -- Execute --
    -------------

--- a/src/clic-subcommand-instance.ads
+++ b/src/clic-subcommand-instance.ads
@@ -66,6 +66,10 @@ package CLIC.Subcommand.Instance is
 
    procedure Display_Help (Keyword : String);
 
+   procedure Print_Man_Page (Short_Description : String;
+                             Long_Description  : AAA.Strings.Vector);
+   --  Print a man page for the command in troff format
+
    Error_No_Command : exception;
    Command_Already_Defined : exception;
 


### PR DESCRIPTION
To git it a try, build the example (`$ cd example && alr build`) and then run `$ ./bin/clic_example --no-tty --man | man -l - `.

@stcarrez I know you like man pages, if you want to take a stab at this.

Here's a snippet of what it looks like for Alire (pipe that into `man -l -` to see the result):
```
.TH alr 1
.SH NAME
alr - Ada LIbrary REpository
.SH SYNOPSIS
.B alr [global options] <command> [command options] [<arguments>]
.SH DESCRIPTION
.P
A catalog of ready-to-use Ada libraries plus a ommand-line tool (`alr`) to
.P
obtain, build, and incorporate them into your own projects. It aims to fulfill
.P
a similar role to Rust's `cargo` or OCaml's `opam`.
.SH GLOBAL OPTIONS
.PP
\-c=, \-\-config=
.RS
Override configuration folder location
.RE
.PP
\-f, \-\-force
.RS
Keep going after a recoverable troublesome situation
.RE
.PP
\-h, \-\-help
.RS
Display general or command-specific help
.RE
.PP
\-n, \-\-non-interactive
.RS
Assume default answers for all user prompts
.RE
.PP
\-\-no-color
.RS
Disables colors in output
.RE
.PP
\-\-no-tty
.RS
Disables control characters in output
.RE
.PP
\-\-prefer-oldest
.RS
Prefer oldest versions instead of newest when resolving dependencies
.RE
.PP
\-q
.RS
Limit output to errors
.RE
.PP
\-v
.RS
Be more verbose (use twice for extra detail)
.RE
.PP
\-d?, \-\-debug?
.RS
Enable debug-specific log messages
.RE
.SH COMMANDS
.SH GENERAL COMMANDS
.PP
\fBhelp\fR [<command>|<topic>]
.RS
Shows help on the given command/topic
.P
Shows information about commands and topics.
See available commands with 'alr help commands'
See available topics with 'alr help topics'.
.RE
.SH INDEX COMMANDS
.PP
\fBget\fR <crate>[allowed versions]
.RS
Fetches a crate release
.P
Retrieve a crate, in the case of regular ones, or install a system package provided by the platform. A regular crate is deployed under an immediate folder with naming 'name_version_hash'.
.P
Version selection syntax (global policy applies within the allowed version subsets):
.P
crate           Newest/oldest version
crate=version   Exact version
crate^version   Major-compatible version
crate~version   Minor-compatible version
.PP
\-b, \-\-build
.RS
Build after download
.RE
.PP
\-o, \-\-only
.RS
Retrieve requested crate only, without dependencies
.RE
.RE
.SH BUILD COMMANDS
.PP
\fBbuild\fR [gprbuild switches and arguments]
.RS
GPRbuild current working release
.P
Invokes gprbuild to compile all targets in the current crate.
.RE
.PP
\fBdev\fR 
.RS
Developer helpers
.P
Internal command for development help. Options and features are not stable and may change without warning.
.PP
\-\-custom
.RS
Execute current custom code
.RE
.PP
\-\-filter
.RS
Used by scope filtering test
.RE
.PP
\-\-raise
.RS
Raise an exception
.RE
.PP
\-\-test
.RS
Run self-tests
.RE
.RE
.SH PUBLISH COMMANDS
.PP
\fBpublish\fR [--skip-build] [--tar] [--manifest <file>] [<URL> [commit]]]
.RS
Help with the publication of a new release
.P
Checks a release and generates an index manifest
.P
See full details at
.P
 https://github.com/alire-project/alire/blob/master/doc/publishing.md
.P
URL is an optional path to a remote source archive, or a local or remote git repository.
.P
For the common use case of a github-hosted repository, issue `alr publish` after committing and pushing the new release version.
.P
Use --tar to create a source archive ready to be uploaded.
.P
Use --manifest to use metadata in a non-default file.
.P
See the above link for help with other scenarios.
.PP
\-\-manifest=
.RS
Selects a manifest file other than ./alire.toml
.RE
.PP
\-\-tar
.RS
Start the publishing assistant to create a source archive from a local directory
.RE
.PP
\-\-trusted-sites
.RS
Print a list of trusted git repository sites
.RE
.PP
\-\-skip-build
.RS
Skip the build check step
.RE
.RE
.SH MISC
.SS User defined command aliases
.P
Command aliases can be defined in local or global 
configuration.
.P
For example the following command:
"$ alr config --set --global alias.graph 'show --graph'"
Defines a global alias for the 'show' command with a 
'--graph' switch.
.P
"$ alr graph" is equivalent to "alr show --graph"
.SS Naming rules for crate and index names
.P
Identifiers for crates and indexes must use lowercase alphanumeric characters from the latin alphabet. Underscores can also be used except as the first character.
.P
Length must be of 3 to 64 characters.
.SS Configuration and use of toolchains
.P
Alire indexes binary releases of GNAT and gprbuild. The compilers are indexed with their target name, e.g., gnat_native or gnat_riscv_elf. 
.P
Use alr toolchain --help to obtain information about toolchain management. Alire can be configured to rely on a toolchain installed by the user in the environment, or to use one of the indexed toolchains whenever possible.
.P
Some crates may override the default toolchain by specifying dependencies on particular compiler crates, for example to use a cross-compiler. In this situation, a compiler already available (selected as default or already installed) will take precedence over a compiler available in the catalog. 
.P
See also https://alire.ada.dev/docs/#toolchains for additional details about compiler dependencies and toolchain interactions.
```