### PR TITLE
Add missing newline before "COMMANDS" and "TOPICS"

### DIFF
--- a/src/clic-subcommand-instance.adb
+++ b/src/clic-subcommand-instance.adb
@@ -282,6 +282,7 @@ package body CLIC.Subcommand.Instance is
          return;
       end if;
 
+      Put_Line ("");
       Put_Line (TTY_Chapter ("COMMANDS"));
 
       for Name of Not_In_A_Group loop
@@ -326,6 +327,7 @@ package body CLIC.Subcommand.Instance is
          return;
       end if;
 
+      Put_Line ("");
       Put_Line (TTY_Chapter ("TOPICS"));
 
       for Elt in Registered_Topics.Iterate loop


### PR DESCRIPTION
Running `alr` would show output with a missing newline before these two titles.