### PR TITLE
Give hint when invalid subcommand switch is a valid global switch

### DIFF
--- a/src/clic-subcommand-instance.ads
+++ b/src/clic-subcommand-instance.ads
@@ -37,7 +37,7 @@ package CLIC.Subcommand.Instance is
    --  Register a sub-command in a group
 
    procedure Register (Topic : not null Help_Topic_Access);
-   --  Register an help topic
+   --  Register a help topic
 
    procedure Set_Alias (Alias : Identifier; Replacement : AAA.Strings.Vector);
    --  Define Alias such that "<Main_Command_Name> <Alias> <Extra_Args>" will
@@ -90,6 +90,9 @@ package CLIC.Subcommand.Instance is
 
    type Builtin_Help is new Command with private;
    --  Use Register (new Builtin_Help); to provide a build-in help command
+
+   function Is_Global_Switch (Switch : String) return Boolean;
+   --  Say if the switch has been defined as global
 
 private
 


### PR DESCRIPTION
Will improve output in the common case in which e.g. `-v` is given after the subcommand.

Related: https://github.com/alire-project/alire/issues/1027