### PR TITLE
Bump version and fix dependency on aaa

### DIFF
--- a/alire.toml
+++ b/alire.toml
@@ -1,6 +1,6 @@
 name = "clic"
 description = "Command Line Interface Components"
-version = "0.2.1-dev"
+version = "0.2.1"
 
 authors = ["Alejandro R. Mosteo", "Fabien Chouteau"]
 maintainers = ["alejandro@mosteo.com", "Fabien Chouteau <fabien.chouteau@gmail.com>"]
@@ -24,4 +24,4 @@ disabled = true # CLIC is an Alire dependency using git submodule, so we can't
 aaa = "~0.2.4"
 simple_logging = "^1.2.0"
 ansiada = "~0.1.0"
-ada_toml = "~0.2.0"
+ada_toml = "~0.2|~0.3"


### PR DESCRIPTION
With this we'll be able to use it as a regular unpinned dependency in `alr`