### PR TITLE
Generic for typed storage of configuration options and `Get_As_String` with default

### DIFF
--- a/src/clic-config-edit.adb
+++ b/src/clic-config-edit.adb
@@ -215,7 +215,8 @@ package body CLIC.Config.Edit is
       --  addition to the user check
       function Check_Proper (Key : Config_Key; Value : TOML.TOML_Value)
                              return Boolean
-      is (Check (Key, Value) and then Value.Kind = TOML_Type);
+      is ((Check = null or else Check (Key, Value))
+          and then Value.Kind = TOML_Type);
 
       -----------------
       -- Set_Boolean --

--- a/src/clic-config-edit.adb
+++ b/src/clic-config-edit.adb
@@ -197,4 +197,47 @@ package body CLIC.Config.Edit is
       return True;
    end Set;
 
+   ---------------
+   -- Set_Typed --
+   ---------------
+
+   function Set_Typed (Path  : String;
+                       Key   : Config_Key;
+                       Value : Value_Type;
+                       Check : Check_Import := null)
+                       return Boolean
+   is
+
+      ------------------
+      -- Check_Proper --
+      ------------------
+      --  Check that the type to be stored is actually the one intended, in
+      --  addition to the user check
+      function Check_Proper (Key : Config_Key; Value : TOML.TOML_Value)
+                             return Boolean
+      is (Check (Key, Value) and then Value.Kind = TOML_Type);
+
+      -----------------
+      -- Set_Boolean --
+      -----------------
+
+      function Set_Boolean return Boolean is
+      begin
+         return Set (Path, Key,
+                     (case Boolean'Value (Image (Value)) is
+                         when True  => "true",
+                         when False => "false"),
+                     Check_Proper'Unrestricted_Access);
+      end Set_Boolean;
+
+   begin
+      if TOML_Type = TOML_Boolean then
+         --  Boolean is special because we need to pass exactly "true/false"
+         return Set_Boolean;
+      else
+         return Set (Path, Key, Image (Value),
+                     Check_Proper'Unrestricted_Access);
+      end if;
+   end Set_Typed;
+
 end CLIC.Config.Edit;

--- a/src/clic-config-edit.ads
+++ b/src/clic-config-edit.ads
@@ -19,4 +19,15 @@ package CLIC.Config.Edit is
    --  configuration file is not modified. In addition the Check function
    --  can print an error message explaining why the key/value is invalid.
 
+   generic
+      type Value_Type is private;       -- The Ada type to store
+      TOML_Type : TOML.Atom_Value_Kind; -- The TOML type it must match
+      with function Image (Value : Value_Type) return String;
+      --  This should be Value_Type'Image
+   function Set_Typed (Path  : String;
+                       Key   : Config_Key;
+                       Value : Value_Type;
+                       Check : Check_Import := null)
+                       return Boolean;
+
 end CLIC.Config.Edit;

--- a/src/clic-config.adb
+++ b/src/clic-config.adb
@@ -100,15 +100,15 @@ package body CLIC.Config is
    -- Get_As_String --
    -------------------
 
-   function Get_As_String (This : Instance;
-                           Key : Config_Key)
-                           return String
+   function Get_As_String (This    : Instance;
+                           Key     : Config_Key;
+                           Default : String) return String
    is
    begin
       if This.Defined (Key) then
          return Image (This.Get (Key).Value);
       else
-         return "";
+         return Default;
       end if;
    end Get_As_String;
 
@@ -116,18 +116,10 @@ package body CLIC.Config is
    -- Get_As_String --
    -------------------
 
-   function Get_As_String (This    : Instance;
-                           Key     : Config_Key;
-                           Default : String) return String
-   is
-      Val : constant String := Get_As_String (This, Key);
-   begin
-      if Val = "" then
-         return Default;
-      else
-         return Val;
-      end if;
-   end Get_As_String;
+    function Get_As_String (This : Instance;
+                            Key : Config_Key)
+                            return String
+   is (Get_As_String (This, Key, Default => ""));
 
    ---------
    -- Get --

--- a/src/clic-config.adb
+++ b/src/clic-config.adb
@@ -112,6 +112,23 @@ package body CLIC.Config is
       end if;
    end Get_As_String;
 
+   -------------------
+   -- Get_As_String --
+   -------------------
+
+   function Get_As_String (This    : Instance;
+                           Key     : Config_Key;
+                           Default : String) return String
+   is
+      Val : constant String := Get_As_String (This, Key);
+   begin
+      if Val = "" then
+         return Default;
+      else
+         return Val;
+      end if;
+   end Get_As_String;
+
    ---------
    -- Get --
    ---------

--- a/src/clic-config.adb
+++ b/src/clic-config.adb
@@ -102,7 +102,7 @@ package body CLIC.Config is
 
    function Get_As_String (This    : Instance;
                            Key     : Config_Key;
-                           Default : String) return String
+                           Default : String := "") return String
    is
    begin
       if This.Defined (Key) then
@@ -111,15 +111,6 @@ package body CLIC.Config is
          return Default;
       end if;
    end Get_As_String;
-
-   -------------------
-   -- Get_As_String --
-   -------------------
-
-    function Get_As_String (This : Instance;
-                            Key : Config_Key)
-                            return String
-   is (Get_As_String (This, Key, Default => ""));
 
    ---------
    -- Get --

--- a/src/clic-config.ads
+++ b/src/clic-config.ads
@@ -50,14 +50,11 @@ package CLIC.Config with Preelaborate is
    function Defined (This : Instance; Key : Config_Key) return Boolean;
    --  Return True if a value is defined for the given key
 
-   function Get_As_String (This : Instance; Key : Config_Key) return String;
-   --  Return a string representation of the value for the given configuration
-   --  Key. If the key is not defined, an empty string is returned.
-
    function Get_As_String (This    : Instance;
                            Key     : Config_Key;
-                           Default : String) return String;
-   --  As Get_As_String, but return Default instead of "" if missing
+                           Default : String := "") return String;
+   --  Return a string representation of the value for the given configuration
+   --  Key. If the key is not defined, Default is returned.
 
    function Get (This    : Instance;
                  Key     : Config_Key;

--- a/src/clic-config.ads
+++ b/src/clic-config.ads
@@ -54,6 +54,11 @@ package CLIC.Config with Preelaborate is
    --  Return a string representation of the value for the given configuration
    --  Key. If the key is not defined, an empty string is returned.
 
+   function Get_As_String (This    : Instance;
+                           Key     : Config_Key;
+                           Default : String) return String;
+   --  As Get_As_String, but return Default instead of "" if missing
+
    function Get (This    : Instance;
                  Key     : Config_Key;
                  Default : Boolean)


### PR DESCRIPTION
These will serve to make a bit more robust the storage of config options in Alire.