### PR TITLE
Remove spurious Boolean warning

### DIFF
--- a/src/clic-user_input.adb
+++ b/src/clic-user_input.adb
@@ -196,7 +196,6 @@ package body CLIC.User_Input is
                Simple_Logging.Info
                  ("Using default choice in non-interactive mode: "
                   & Choices.First_Element);
-               Simple_Logging.Warning (TTY.Is_TTY'Img);
                return Choices.First_Index;
             end if;
 


### PR DESCRIPTION
Remove a warning from `Query_Multi` in non-interactive mode.

E.g. `alr -n init xxx` currently yields
```
Select the kind of crate you want to create:
Using default choice in non-interactive mode: LIBRARY
warn: TRUE
```
and
```
Select a software license for the crate?
Using default choice in non-interactive mode: MIT OR Apache-2.0 WITH LLVM-exception
warn: TRUE
```

I'm assuming this is an unintentional leftover from some debugging?
