### PR TITLE
Get nearest command when misstyping

### DIFF
--- a/alire.toml
+++ b/alire.toml
@@ -1,6 +1,6 @@
 name = "clic"
 description = "Command Line Interface Components"
-version = "0.3.0"
+version = "0.4.0"
 
 authors = ["Alejandro R. Mosteo", "Fabien Chouteau"]
 maintainers = ["alejandro@mosteo.com", "Fabien Chouteau <fabien.chouteau@gmail.com>"]

--- a/example/src/clic_ex-commands.ads
+++ b/example/src/clic_ex-commands.ads
@@ -28,5 +28,6 @@ private
       TTY_Description     => CLIC.TTY.Description,
       TTY_Version         => CLIC.TTY.Version,
       TTY_Underline       => CLIC.TTY.Underline,
-      TTY_Emph            => CLIC.TTY.Emph);
+      TTY_Emph            => CLIC.TTY.Emph,
+      Misstyping_Correction_Distance => 3);
 end CLIC_Ex.Commands;

--- a/example/src/clic_ex-commands.ads
+++ b/example/src/clic_ex-commands.ads
@@ -29,5 +29,5 @@ private
       TTY_Version         => CLIC.TTY.Version,
       TTY_Underline       => CLIC.TTY.Underline,
       TTY_Emph            => CLIC.TTY.Emph,
-      Misstyping_Correction_Distance => 3);
+      Misstyping_Correction_Distance => 4);
 end CLIC_Ex.Commands;

--- a/src/clic-subcommand-instance.adb
+++ b/src/clic-subcommand-instance.adb
@@ -1047,44 +1047,53 @@ package body CLIC.Subcommand.Instance is
    end Is_Global_Switch;
 
    procedure Closest_Command (User_Input : String) is
-      Least_Distance : Natural := Natural'Last;
+      Least_Distance : Natural := 999;
       Closest_Command : Command_Access;
-      Distance : Natural := Natural'Last;
+      Distance : Natural := 999;
 
-      ----------------------------
-      --  Levenshtein_Distance  --
-      ----------------------------
-      -- It's expected that CLIC does not have too many commands
-      -- Therefore only naive recursive implementation is used
-      function Levenshtein_Distance (User_Input : String; Possible_Command : Identifier) return Natural is
+      -------------------------------
+      -- Levenshtein_Edit_Distance --
+      -------------------------------
+
+      function Levenshtein_Edit_Distance (S, T : String) return Natural is
+         D : array (S'First - 1 .. S'Last, T'First - 1 .. T'Last) of Natural;
       begin
-         if User_Input'Length = 0 or Possible_Command'Length = 0 then
-            return 0;
-         elsif User_Input'First = Possible_Command'First then
-            return Levenshtein_Distance (
-              User_Input (User_Input'First + 1 .. User_Input'Length),
-              Possible_Command (Possible_Command'First + 1 .. Possible_Command'Length));
-         else
-            return 1 + Natural'Min (Natural'Min (
-              Levenshtein_Distance (
-                User_Input (User_Input'First + 1 .. User_Input'Length),
-                Possible_Command),
-              Levenshtein_Distance (
-                User_Input,
-                Possible_Command (Possible_Command'First + 1 .. Possible_Command'Length))),
-                   Levenshtein_Distance (
-                     User_Input (User_Input'First + 1 .. User_Input'Length),
-                     Possible_Command (Possible_Command'First + 1 .. Possible_Command'Length)));
-         end if;
-      end Levenshtein_Distance;
+         for I in D'Range (1) loop
+            D (I, T'First - 1) := I;
+         end loop;
+
+         for J in D'Range (2) loop
+            D (S'First - 1, J) := J;
+         end loop;
+
+         for I in S'Range loop
+            for J in T'Range loop
+               declare
+                  Cost : constant Natural :=
+                    (if S (I) = T (J)
+                     then 0
+                     else 1);
+
+                  A : constant Natural := D (I - 1, J) + 1;
+                  B : constant Natural := D (I, J - 1) + 1;
+                  C : constant Natural := D (I - 1, J - 1) + Cost;
+               begin
+
+                  D (I, J) := Natural'Min (Natural'Min (A, B), C);
+               end;
+            end loop;
+         end loop;
+
+         return D (D'Last (1), D'Last (2));
+      end Levenshtein_Edit_Distance;
 
    begin
-      for Commands of Registered_Commands loop
-          Distance := Levenshtein_Distance (Global_Arguments.First_Element, Commands.Name);
-          if Distance < Least_Distance then
-             Least_Distance := Distance;
-             Closest_Command := Commands;
-          end if;
+      for Cmd of Registered_Commands loop
+         Distance := Levenshtein_Edit_Distance (User_Input, Cmd.Name);
+         if Distance < Least_Distance then
+            Least_Distance := Distance;
+            Closest_Command := Cmd;
+         end if;
       end loop;
 
       if Least_Distance < Misstyping_Correction_Distance then

--- a/src/clic-subcommand-instance.adb
+++ b/src/clic-subcommand-instance.adb
@@ -770,48 +770,11 @@ package body CLIC.Subcommand.Instance is
          Put_Error ("Unrecognized command: " & Global_Arguments.First_Element);
          Put_Line ("");
 
-         declare
-            Least_Distance : Natural := Natural'Last;
-            Closest_Command : Command_Access;
-            Distance : Natural := Natural'Last;
-
-            ----------------------------
-            --  Levenshtein_Distance  --
-            ----------------------------
-            -- It's expected that CLIC does not have too many commands
-            -- Therefore only a simple naive implementation is used
-            function Levenshtein_Distance (User_Input : String; Possible_Command : Identifier) return Natural is
-            begin
-               if User_Input (0) = Possible_Command (0) then
-                  return Levenshtein_Distance (
-                    User_Input (1 .. User_Input'Length),
-                    Possible_Command (1 .. Possible_Command'Length));
-               else
-                  return 0;
-                  --  TODO:
-                  --  implement using recusion (simple but _slow_)   OR
-                  --  use Distance crate       (adds new dependency) OR
-                  --  implment Matrix table... (hard and MANY LOC)
-                  --  Use Wagner-Fischer or Hirschberg?
-               end if;
-            end Levenshtein_Distance;
-
-         begin
-            for Commands in Registered_Commands loop
-                Distance := Levenshtein_Distance (Global_Arguments.First_Element, Command.Name);
-                if Distance < Least_Distance then
-                   Least_Distance := Distance;
-                   Closest_Command := Command;
-                end if;
-            end loop;
-
-            if Least_Distance < 3 then
-
-               Put_Line ("Most similar command is " & Closest_Command.Name);
-            else
-               Display_Usage (Displayed_Error => True);
-            end if;
-         end;
+         if Misstyping_Correction_Distance /= 0 then
+            Closest_Command (Global_Arguments.First_Element);
+         else
+            Display_Usage (Displayed_Error => True);
+         end if;
          Error_Exit (1);
    end Execute;
 
@@ -1082,5 +1045,53 @@ package body CLIC.Subcommand.Instance is
       GNAT.OS_Lib.Free (Command_Line);
       return Result;
    end Is_Global_Switch;
+
+   procedure Closest_Command (User_Input : String) is
+      Least_Distance : Natural := Natural'Last;
+      Closest_Command : Command_Access;
+      Distance : Natural := Natural'Last;
+
+      ----------------------------
+      --  Levenshtein_Distance  --
+      ----------------------------
+      -- It's expected that CLIC does not have too many commands
+      -- Therefore only naive recursive implementation is used
+      function Levenshtein_Distance (User_Input : String; Possible_Command : Identifier) return Natural is
+      begin
+         if User_Input'Length = 0 or Possible_Command'Length = 0 then
+            return 0;
+         elsif User_Input'First = Possible_Command'First then
+            return Levenshtein_Distance (
+              User_Input (User_Input'First + 1 .. User_Input'Length),
+              Possible_Command (Possible_Command'First + 1 .. Possible_Command'Length));
+         else
+            return 1 + Natural'Min (Natural'Min (
+              Levenshtein_Distance (
+                User_Input (User_Input'First + 1 .. User_Input'Length),
+                Possible_Command),
+              Levenshtein_Distance (
+                User_Input,
+                Possible_Command (Possible_Command'First + 1 .. Possible_Command'Length))),
+                   Levenshtein_Distance (
+                     User_Input (User_Input'First + 1 .. User_Input'Length),
+                     Possible_Command (Possible_Command'First + 1 .. Possible_Command'Length)));
+         end if;
+      end Levenshtein_Distance;
+
+   begin
+      for Commands of Registered_Commands loop
+          Distance := Levenshtein_Distance (Global_Arguments.First_Element, Commands.Name);
+          if Distance < Least_Distance then
+             Least_Distance := Distance;
+             Closest_Command := Commands;
+          end if;
+      end loop;
+
+      if Least_Distance < Misstyping_Correction_Distance then
+         Put_Line ("Most similar command is " & Closest_Command.Name);
+      else
+         Display_Usage (Displayed_Error => True);
+      end if;
+   end Closest_Command;
 
 end CLIC.Subcommand.Instance;

--- a/src/clic-subcommand-instance.adb
+++ b/src/clic-subcommand-instance.adb
@@ -771,6 +771,7 @@ package body CLIC.Subcommand.Instance is
          Put_Line ("");
 
          if Misstyping_Correction_Distance /= 0 then
+            --  Don't even check if distance is 0
             Closest_Command (Global_Arguments.First_Element);
          else
             Display_Usage (Displayed_Error => True);

--- a/src/clic-subcommand-instance.adb
+++ b/src/clic-subcommand-instance.adb
@@ -769,7 +769,49 @@ package body CLIC.Subcommand.Instance is
       when Error_No_Command =>
          Put_Error ("Unrecognized command: " & Global_Arguments.First_Element);
          Put_Line ("");
-         Display_Usage (Displayed_Error => True);
+
+         declare
+            Least_Distance : Natural := Natural'Last;
+            Closest_Command : Command_Access;
+            Distance : Natural := Natural'Last;
+
+            ----------------------------
+            --  Levenshtein_Distance  --
+            ----------------------------
+            -- It's expected that CLIC does not have too many commands
+            -- Therefore only a simple naive implementation is used
+            function Levenshtein_Distance (User_Input : String; Possible_Command : Identifier) return Natural is
+            begin
+               if User_Input (0) = Possible_Command (0) then
+                  return Levenshtein_Distance (
+                    User_Input (1 .. User_Input'Length),
+                    Possible_Command (1 .. Possible_Command'Length));
+               else
+                  return 0;
+                  --  TODO:
+                  --  implement using recusion (simple but _slow_)   OR
+                  --  use Distance crate       (adds new dependency) OR
+                  --  implment Matrix table... (hard and MANY LOC)
+                  --  Use Wagner-Fischer or Hirschberg?
+               end if;
+            end Levenshtein_Distance;
+
+         begin
+            for Commands in Registered_Commands loop
+                Distance := Levenshtein_Distance (Global_Arguments.First_Element, Command.Name);
+                if Distance < Least_Distance then
+                   Least_Distance := Distance;
+                   Closest_Command := Command;
+                end if;
+            end loop;
+
+            if Least_Distance < 3 then
+
+               Put_Line ("Most similar command is " & Closest_Command.Name);
+            else
+               Display_Usage (Displayed_Error => True);
+            end if;
+         end;
          Error_Exit (1);
    end Execute;
 

--- a/src/clic-subcommand-instance.adb
+++ b/src/clic-subcommand-instance.adb
@@ -12,6 +12,7 @@ with AAA.Text_IO;
 
 with CLIC.Config.Info;
 with CLIC.Command_Line; use CLIC.Command_Line;
+with CLIC.Utils;
 
 package body CLIC.Subcommand.Instance is
 
@@ -771,7 +772,6 @@ package body CLIC.Subcommand.Instance is
          Put_Line ("");
 
          if Misstyping_Correction_Distance /= 0 then
-            --  Don't even check if distance is 0
             Closest_Command (Global_Arguments.First_Element);
          else
             Display_Usage (Displayed_Error => True);
@@ -1047,50 +1047,17 @@ package body CLIC.Subcommand.Instance is
       return Result;
    end Is_Global_Switch;
 
+   -----------------------
+   --  Closest_Command  --
+   -----------------------
+
    procedure Closest_Command (User_Input : String) is
-      Least_Distance : Natural := 999;
+      Least_Distance : Natural := Natural'Last;
       Closest_Command : Command_Access;
-      Distance : Natural := 999;
-
-      -------------------------------
-      -- Levenshtein_Edit_Distance --
-      -------------------------------
-
-      function Levenshtein_Edit_Distance (S, T : String) return Natural is
-         D : array (S'First - 1 .. S'Last, T'First - 1 .. T'Last) of Natural;
-      begin
-         for I in D'Range (1) loop
-            D (I, T'First - 1) := I;
-         end loop;
-
-         for J in D'Range (2) loop
-            D (S'First - 1, J) := J;
-         end loop;
-
-         for I in S'Range loop
-            for J in T'Range loop
-               declare
-                  Cost : constant Natural :=
-                    (if S (I) = T (J)
-                     then 0
-                     else 1);
-
-                  A : constant Natural := D (I - 1, J) + 1;
-                  B : constant Natural := D (I, J - 1) + 1;
-                  C : constant Natural := D (I - 1, J - 1) + Cost;
-               begin
-
-                  D (I, J) := Natural'Min (Natural'Min (A, B), C);
-               end;
-            end loop;
-         end loop;
-
-         return D (D'Last (1), D'Last (2));
-      end Levenshtein_Edit_Distance;
-
+      Distance : Natural := Natural'Last;
    begin
       for Cmd of Registered_Commands loop
-         Distance := Levenshtein_Edit_Distance (User_Input, Cmd.Name);
+         Distance := CLIC.Utils.Levenshtein_Edit_Distance (User_Input, Cmd.Name);
          if Distance < Least_Distance then
             Least_Distance := Distance;
             Closest_Command := Cmd;

--- a/src/clic-subcommand-instance.adb
+++ b/src/clic-subcommand-instance.adb
@@ -782,13 +782,19 @@ package body CLIC.Subcommand.Instance is
          Put_Error ("Unrecognized command: " & Global_Arguments.First_Element);
          Put_Line ("");
 
-         if Misstyping_Correction_Distance /= 0 then
-            Put_Line (CLIC.Utils.Suggestion (
+         declare
+            Res : constant String := CLIC.Utils.Suggestion (
               Global_Arguments.First_Element,
-              Commands_To_Vector));
-         else
-            Display_Usage (Displayed_Error => True);
-         end if;
+              Commands_To_Vector,
+              Misstyping_Correction_Distance);
+         begin
+            if Res = "" then
+               Display_Usage (Displayed_Error => True);
+            else
+               Put_Line (Res);
+            end if;
+         end;
+
          Error_Exit (1);
    end Execute;
 

--- a/src/clic-subcommand-instance.adb
+++ b/src/clic-subcommand-instance.adb
@@ -649,6 +649,17 @@ package body CLIC.Subcommand.Instance is
       Parser : Opt_Parser;
       --  Subcommand parser, declared here so it is available to the exception
       --  handler below.
+
+      function Commands_To_Vector return AAA.Strings.Vector is
+         Result : AAA.Strings.Vector := AAA.Strings.Empty_Vector;
+      begin
+         for C in Registered_Commands.Iterate loop
+            AAA.Strings.Append (Result, To_String(Command_Maps.Key (C)));
+         end loop;
+
+         return Result;
+      end Commands_To_Vector;
+      --  Need to convert commands to accepted type by Clic.Utils.Suggestion
    begin
 
       Parse_Global_Switches (Command_Line);
@@ -772,7 +783,9 @@ package body CLIC.Subcommand.Instance is
          Put_Line ("");
 
          if Misstyping_Correction_Distance /= 0 then
-            Closest_Command (Global_Arguments.First_Element);
+            Put_Line (CLIC.Utils.Suggestion (
+              Global_Arguments.First_Element,
+              Commands_To_Vector));
          else
             Display_Usage (Displayed_Error => True);
          end if;
@@ -1046,29 +1059,5 @@ package body CLIC.Subcommand.Instance is
       GNAT.OS_Lib.Free (Command_Line);
       return Result;
    end Is_Global_Switch;
-
-   -----------------------
-   --  Closest_Command  --
-   -----------------------
-
-   procedure Closest_Command (User_Input : String) is
-      Least_Distance : Natural := Natural'Last;
-      Closest_Command : Command_Access;
-      Distance : Natural := Natural'Last;
-   begin
-      for Cmd of Registered_Commands loop
-         Distance := CLIC.Utils.Levenshtein_Edit_Distance (User_Input, Cmd.Name);
-         if Distance < Least_Distance then
-            Least_Distance := Distance;
-            Closest_Command := Cmd;
-         end if;
-      end loop;
-
-      if Least_Distance < Misstyping_Correction_Distance then
-         Put_Line ("Most similar command is " & Closest_Command.Name);
-      else
-         Display_Usage (Displayed_Error => True);
-      end if;
-   end Closest_Command;
 
 end CLIC.Subcommand.Instance;

--- a/src/clic-subcommand-instance.ads
+++ b/src/clic-subcommand-instance.ads
@@ -33,9 +33,10 @@ generic
    --  options (that apply to all subcommands).
 
    Misstyping_Correction_Distance : Natural := 0;
-   --  Suggest the closesed command when user missclicks. Takes the Levenshtein
-   --  distance as a parameter.
-   --  Is Disabled when 0 and always enabled when Natrual'Least
+   --  Suggest the closesed command when user misstypes. Takes the Levenshtein
+   --  edit distance as a parameter.
+   --  Is Disabled when 0 and always enabled when Natrual'Least.
+   --  Has to be applied to subcommands as well.
 
 package CLIC.Subcommand.Instance is
 

--- a/src/clic-subcommand-instance.ads
+++ b/src/clic-subcommand-instance.ads
@@ -32,6 +32,11 @@ generic
    --  When listing help for a subcommand, also include a section on global
    --  options (that apply to all subcommands).
 
+   Misstyping_Correction_Distance : Natural := 0;
+   --  Suggest the closesed command when user missclicks. Takes the Levenshtein
+   --  distance as a parameter.
+   --  Is Disabled when 0 and always enabled when Natrual'Least
+
 package CLIC.Subcommand.Instance is
 
    procedure Register (Cmd : not null Command_Access);
@@ -105,11 +110,11 @@ private
 
    overriding
    function Name (This : Builtin_Help) return Identifier
-   is ("help");
+     is ("help");
 
    overriding
    function Switch_Parsing (This : Builtin_Help) return Switch_Parsing_Kind
-   is (Parse_All);
+     is (Parse_All);
 
    overriding
    procedure Execute (This : in out Builtin_Help;
@@ -117,26 +122,28 @@ private
 
    overriding
    function Long_Description (This : Builtin_Help)
-                              return AAA.Strings.Vector
-   is (AAA.Strings.Empty_Vector
+     return AAA.Strings.Vector
+     is (AAA.Strings.Empty_Vector
        .Append ("Shows information about commands and topics.")
        .Append ("See available commands with '" &
-           Main_Command_Name & " help commands'")
+                Main_Command_Name & " help commands'")
        .Append ("See available topics with '" &
-           Main_Command_Name & " help topics'."));
+                Main_Command_Name & " help topics'."));
 
    overriding
    procedure Setup_Switches
      (This    : in out Builtin_Help;
       Config  : in out CLIC.Subcommand.Switches_Configuration)
-   is null;
+     is null;
 
    overriding
    function Short_Description (This : Builtin_Help) return String
-   is ("Shows help on the given command/topic");
+     is ("Shows help on the given command/topic");
 
    overriding
    function Usage_Custom_Parameters (This : Builtin_Help) return String
-   is ("[<command>|<topic>]");
+     is ("[<command>|<topic>]");
+
+   procedure Closest_Command (User_Input : String);
 
 end CLIC.Subcommand.Instance;

--- a/src/clic-subcommand-instance.ads
+++ b/src/clic-subcommand-instance.ads
@@ -35,7 +35,7 @@ generic
    Misstyping_Correction_Distance : Natural := 0;
    --  Suggest the closesed command when user misstypes. Takes the Levenshtein
    --  edit distance as a parameter.
-   --  Is Disabled when 0 and always enabled when Natrual'Least.
+   --  Is Disabled when 0 and always enabled when Natrual'Last.
    --  Has to be applied to subcommands as well.
 
 package CLIC.Subcommand.Instance is
@@ -144,7 +144,5 @@ private
    overriding
    function Usage_Custom_Parameters (This : Builtin_Help) return String
      is ("[<command>|<topic>]");
-
-   procedure Closest_Command (User_Input : String);
 
 end CLIC.Subcommand.Instance;

--- a/src/clic-subcommand-instance.ads
+++ b/src/clic-subcommand-instance.ads
@@ -35,7 +35,7 @@ generic
    Misstyping_Correction_Distance : Natural := 0;
    --  Suggest the closesed command when user misstypes. Takes the Levenshtein
    --  edit distance as a parameter.
-   --  Is Disabled when 0 and always enabled when Natrual'Last.
+   --  Takes the value as the distance. Disabled when 0;
    --  Has to be applied to subcommands as well.
 
 package CLIC.Subcommand.Instance is
@@ -111,11 +111,11 @@ private
 
    overriding
    function Name (This : Builtin_Help) return Identifier
-     is ("help");
+   is ("help");
 
    overriding
    function Switch_Parsing (This : Builtin_Help) return Switch_Parsing_Kind
-     is (Parse_All);
+   is (Parse_All);
 
    overriding
    procedure Execute (This : in out Builtin_Help;
@@ -123,26 +123,26 @@ private
 
    overriding
    function Long_Description (This : Builtin_Help)
-     return AAA.Strings.Vector
-     is (AAA.Strings.Empty_Vector
+                              return AAA.Strings.Vector
+   is (AAA.Strings.Empty_Vector
        .Append ("Shows information about commands and topics.")
        .Append ("See available commands with '" &
-                Main_Command_Name & " help commands'")
+           Main_Command_Name & " help commands'")
        .Append ("See available topics with '" &
-                Main_Command_Name & " help topics'."));
+           Main_Command_Name & " help topics'."));
 
    overriding
    procedure Setup_Switches
      (This    : in out Builtin_Help;
       Config  : in out CLIC.Subcommand.Switches_Configuration)
-     is null;
+   is null;
 
    overriding
    function Short_Description (This : Builtin_Help) return String
-     is ("Shows help on the given command/topic");
+   is ("Shows help on the given command/topic");
 
    overriding
    function Usage_Custom_Parameters (This : Builtin_Help) return String
-     is ("[<command>|<topic>]");
+   is ("[<command>|<topic>]");
 
 end CLIC.Subcommand.Instance;

--- a/src/clic-utils.adb
+++ b/src/clic-utils.adb
@@ -1,0 +1,37 @@
+package body CLIC.Utils is
+   -------------------------------
+   -- Levenshtein_Edit_Distance --
+   -------------------------------
+
+   function Levenshtein_Edit_Distance (S, T : String) return Natural is
+      D : array (S'First - 1 .. S'Last, T'First - 1 .. T'Last) of Natural;
+   begin
+      for I in D'Range (1) loop
+         D (I, T'First - 1) := I;
+      end loop;
+
+      for J in D'Range (2) loop
+         D (S'First - 1, J) := J;
+      end loop;
+
+      for I in S'Range loop
+         for J in T'Range loop
+            declare
+               Cost : constant Natural :=
+                 (if S (I) = T (J)
+                  then 0
+                  else 1);
+
+               A : constant Natural := D (I - 1, J) + 1;
+               B : constant Natural := D (I, J - 1) + 1;
+               C : constant Natural := D (I - 1, J - 1) + Cost;
+            begin
+
+               D (I, J) := Natural'Min (Natural'Min (A, B), C);
+            end;
+         end loop;
+      end loop;
+
+      return D (D'Last (1), D'Last (2));
+   end Levenshtein_Edit_Distance;
+end CLIC.Utils;

--- a/src/clic-utils.adb
+++ b/src/clic-utils.adb
@@ -1,5 +1,3 @@
-with TOML; use TOML;
-
 package body CLIC.Utils with Preelaborate is
 
    -------------------------------

--- a/src/clic-utils.adb
+++ b/src/clic-utils.adb
@@ -41,12 +41,13 @@ package body CLIC.Utils with Preelaborate is
    ----------------
 
    function Suggestion (Input           : String;
-                        Possible_Values : AAA.Strings.Vector)
+                        Possible_Values : AAA.Strings.Vector;
+                        Distance        : Natural)
      return String
    is
-      Min_Dist : Natural := Natural'Last;
-      Dist : Natural;
-      Closest : Positive := Possible_Values.First_Index;
+      Min_Dist : Natural  := Natural'Last;
+      Dist     : Natural;
+      Closest  : Positive := Possible_Values.First_Index;
    begin
       for Index in Possible_Values.First_Index .. Possible_Values.Last_Index
       loop
@@ -64,9 +65,28 @@ package body CLIC.Utils with Preelaborate is
          if Relevant then
             return " Did you mean '" & Possible_Values (Closest) & "'?";
          else
-            return " Can be: " & Possible_Values.Flatten (", ") & ".";
+            return "";
          end if;
       end;
+   end Suggestion;
+
+   ----------------
+   -- Suggestion --
+   ----------------
+
+   function Suggestion (Input           : String;
+                        Possible_Values : AAA.Strings.Vector)
+     return String
+   is
+      Result : constant String := Suggestion (Input,
+                                              Possible_Values,
+                                              Distance => 0);
+   begin
+      if Result = "" then
+         return " Can be: " & Possible_Values.Flatten (", ") & ".";
+      else
+         return Result;
+      end if;
    end Suggestion;
 
    ---------------------

--- a/src/clic-utils.adb
+++ b/src/clic-utils.adb
@@ -45,7 +45,7 @@ package body CLIC.Utils with Preelaborate is
                         Distance        : Natural)
      return String
    is
-      Min_Dist : Natural  := Natural'Last;
+      Min_Dist : Natural  := Distance;
       Dist     : Natural;
       Closest  : Positive := Possible_Values.First_Index;
    begin
@@ -59,7 +59,7 @@ package body CLIC.Utils with Preelaborate is
       end loop;
 
       declare
-         Relevant : constant Boolean := Min_Dist < Input'Length / 2;
+         Relevant : constant Boolean := Min_Dist < Input'Length / 2 and Min_Dist < Distance;
          --  Heuristic for relevance of suggestion
       begin
          if Relevant then
@@ -80,7 +80,7 @@ package body CLIC.Utils with Preelaborate is
    is
       Result : constant String := Suggestion (Input,
                                               Possible_Values,
-                                              Distance => 0);
+                                              Distance => Natural'Last);
    begin
       if Result = "" then
          return " Can be: " & Possible_Values.Flatten (", ") & ".";

--- a/src/clic-utils.adb
+++ b/src/clic-utils.adb
@@ -1,4 +1,7 @@
-package body CLIC.Utils is
+with TOML; use TOML;
+
+package body CLIC.Utils with Preelaborate is
+
    -------------------------------
    -- Levenshtein_Edit_Distance --
    -------------------------------
@@ -34,4 +37,57 @@ package body CLIC.Utils is
 
       return D (D'Last (1), D'Last (2));
    end Levenshtein_Edit_Distance;
+
+   ----------------
+   -- Suggestion --
+   ----------------
+
+   function Suggestion (Input           : String;
+                        Possible_Values : AAA.Strings.Vector)
+     return String
+   is
+      Min_Dist : Natural := Natural'Last;
+      Dist : Natural;
+      Closest : Positive := Possible_Values.First_Index;
+   begin
+      for Index in Possible_Values.First_Index .. Possible_Values.Last_Index
+      loop
+         Dist := Levenshtein_Edit_Distance (Input, Possible_Values (Index));
+         if Dist < Min_Dist then
+            Min_Dist := Dist;
+            Closest := Index;
+         end if;
+      end loop;
+
+      declare
+         Relevant : constant Boolean := Min_Dist < Input'Length / 2;
+         --  Heuristic for relevance of suggestion
+      begin
+         if Relevant then
+            return " Did you mean '" & Possible_Values (Closest) & "'?";
+         else
+            return " Can be: " & Possible_Values.Flatten (", ") & ".";
+         end if;
+      end;
+   end Suggestion;
+
+   ---------------------
+   -- Enum_Suggestion --
+   ---------------------
+   
+   function Enum_Suggestion (Input : String) return String is
+      Possible_Values : AAA.Strings.Vector;
+   begin
+      for V in Enum loop
+         Possible_Values.Append
+           (case Transform is
+               when None       => V'Img,
+               when Lower_Case => AAA.Strings.To_Lower_Case (V'Img),
+               when Upper_Case => AAA.Strings.To_Upper_Case (V'Img),
+               when Tomify     => Tomify (V'Img));
+      end loop;
+   
+      return Suggestion (Input, Possible_Values);
+   end Enum_Suggestion;
+
 end CLIC.Utils;

--- a/src/clic-utils.ads
+++ b/src/clic-utils.ads
@@ -1,0 +1,5 @@
+package CLIC.Utils is
+
+   function Levenshtein_Edit_Distance (S, T : String) return Natural;
+
+end CLIC.Utils;

--- a/src/clic-utils.ads
+++ b/src/clic-utils.ads
@@ -1,5 +1,33 @@
-package CLIC.Utils is
+with AAA.Strings;
 
-   function Levenshtein_Edit_Distance (S, T : String) return Natural;
+package CLIC.Utils with Preelaborate is
+
+   function Suggestion (Input           : String;
+                        Possible_Values : AAA.Strings.Vector)
+     return String;
+   --  Return "Did you mean '<suggestion>'?" if a good enought suggestion
+   --  can be found in Possible_Value, otherwise return an empty string.
+
+   type String_Transform is (None, Lower_Case, Upper_Case, Tomify);
+
+   generic
+      type Enum is (<>);
+      Transform : String_Transform;
+   function Enum_Suggestion (Input : String) return String;
+   --  Convert all possible Enum values in a string vector and call Suggestion.
+   --  The enum string values are converted acording to the Transform value.
+
+   function Tomify (Image : String) return String;
+
+private
+   --  function Tomify (Image : String) return String;
+
+   function Tomify (Image : String) return String is
+     (AAA.Strings.Replace
+        (AAA.Strings.To_Lower_Case (Image),
+         Match => "_",
+         Subst => "-"));
+   --  Take some enumeration image and turn it into a TOML-style key, replacing
+   --  every "_" with a "-" and in lower case.
 
 end CLIC.Utils;

--- a/src/clic-utils.ads
+++ b/src/clic-utils.ads
@@ -3,10 +3,17 @@ with AAA.Strings;
 package CLIC.Utils with Preelaborate is
 
    function Suggestion (Input           : String;
+                        Possible_Values : AAA.Strings.Vector;
+                        Distance        : Natural)
+     return String;
+   --  Return "Did you mean '<suggestion>'?" if suggestions are closer then
+   --  `Distance` and are in `Possible_Values`, otherwise return an empty string.
+
+   function Suggestion (Input           : String;
                         Possible_Values : AAA.Strings.Vector)
      return String;
    --  Return "Did you mean '<suggestion>'?" if a good enought suggestion
-   --  can be found in Possible_Value, otherwise return an empty string.
+   --  can be found in `Possible_Values`, otherwise return `Possible_Values`
 
    type String_Transform is (None, Lower_Case, Upper_Case, Tomify);
 
@@ -20,7 +27,6 @@ package CLIC.Utils with Preelaborate is
    function Tomify (Image : String) return String;
 
 private
-   --  function Tomify (Image : String) return String;
 
    function Tomify (Image : String) return String is
      (AAA.Strings.Replace


### PR DESCRIPTION
fix https://github.com/alire-project/clic/issues/34

I wanted to implement the levenshtein distance function in order to determine the closest command that exist. But depending on the implementation the runtime varies a lot.

My current options are
 1. Use naive recursion
 It's easy to implement but it's terrible for lots of long command names and it recalculates values. 
 2. Use the [Distance](https://github.com/adarium-labs/distance) crate
 If it were not SPARKed I wouldn't suggest it since we would add a new dependency just for this feature.
 3. Use a different more efficient algo
 It would add a lot of code just to implement the distance function and I'm not sure which algo would be better (or even overkill) for this feature.
 
Optimizing the function can be done later on tho.
 
[Context]
When running `alr buidl`  alire prints out the help page as it does not know the command "buidl". 
This has been bugging me for a while now ~~and was a good excuse to procrastinate on other alire issues that I wanted to resolve.~~ 

Note to self: todo add `Select_Nearest_Command` and `Nearest_Command_Distance` to generic subcommand instance (with defaults).

It's not done yet! I wanted to get some input on which algo to use before I implement something not worth while